### PR TITLE
babel 6 works if it's a direct dependency of riot-brunch

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,1 @@
+{ "presets": ["es2015-riot"] }

--- a/package.json
+++ b/package.json
@@ -12,10 +12,12 @@
     "test": "node_modules/.bin/mocha"
   },
   "dependencies": {
-    "riot": "^2.3.1"
+    "riot": "^2.3.12"
   },
   "devDependencies": {
-    "mocha": "1.11.0",
-    "chai": "1.7.0"
+    "babel-core": "^6.4.0",
+    "babel-preset-es2015-riot": "^1.0.1",
+    "chai": "1.7.0",
+    "mocha": "1.11.0"
   }
 }


### PR DESCRIPTION
because breaking your transpiler engenders goodwill

I'm no npm expert, so if there's a better way to do this apart from dragging babel in, that'd be better. I tried just upping the version of riot and including babel 6 etc. in the project that was using riot-brunch, but that didn't work. I feel like that's a solved problem I just don't know how to duckduckgo for.
