### PR TITLE
Add file path to compiler

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ RiotCompiler.prototype.type = 'javascript';
 RiotCompiler.prototype.compile = function(data, path, callback) {
   var compiled;
   try {
-    compiled = compile(data, this.compiler_options);
+    compiled = compile(data, this.compiler_options, path);
   } catch (err) {
     var loc = err.location,
       error;


### PR DESCRIPTION
`riot@2.3.12` added `url` as third parameter to the compile method.
We need to forward the `path` from brunch to Riot's compiler.

This is especially useful when dealing with Jade's `include` with relative
path, as the template file's path will be passed to `filename` option of
Jade's compiler.
