### PR TITLE
Support for dependencies

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,9 @@
 var compile = require('riot').compile;
+var progeny = require('progeny');
 
 RiotCompiler = function(config) {
   this.config = (config && config.plugins && config.plugins.riot) || {};
+  this.rootPath = config.paths.root;
 
   // grab any compiler options
   this.compiler_options = {};
@@ -43,5 +45,9 @@ RiotCompiler.prototype.compile = function(data, path, callback) {
   };
   return callback(null, result);
 };
+
+RiotCompiler.prototype.getDependencies = function(sourceContents, file, callback) {
+  progeny({rootPath: this.rootPath})(file, sourceContents, callback);
+}
 
 module.exports = RiotCompiler;

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "test": "node_modules/.bin/mocha"
   },
   "dependencies": {
+    "progeny": "^0.5.2",
     "riot": "^2.3.12"
   },
   "devDependencies": {


### PR DESCRIPTION
Brunch won't recompile tag file if it has any include/import-d
files and they are changed. For example, if Jade is used for
template, and it `include`s LESS file or CoffeeScript file,
making change to those files will not trigger Brunch's build.

This commit uses `progeny` to retrieve those dependencies from
the source file and pass to Brunch to keep track of.
