### PR TITLE
Update to latest brunch plugin API.

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,62 +3,67 @@ var compile = require('riot').compile;
 var progeny = require('progeny');
 
 class RiotCompiler {
-    constructor(config) {
-      this.config = (config && config.plugins && config.plugins.riot) || {};
-      this.rootPath = config.paths.root;
+  constructor(config) {
+    this.config = (config && config.plugins && config.plugins.riot) || {};
+    this.rootPath = config.paths.root;
 
-      // grab any compiler options
-      this.compiler_options = {};
-      if (this.config.template) {
-        this.compiler_options.template = this.config.template;
-      }
-      this.compiler_options.type = this.config.type;
+    // grab any compiler options
+    this.compiler_options = {};
+    if (this.config.template) {
+      this.compiler_options.template = this.config.template;
+    }
+    this.compiler_options.type = this.config.type;
 
-      // We prefer, in this order, an explicit pattern, an explicit
-      // extention, or a default extension
-      if (this.config.pattern) {
-        this.pattern = this.config.pattern;
-      } else if (this.config.extension) {
-        this.extension = this.config.extension;
-      } else {
-        this.pattern = /\.tag$/;
-      }
+    // We prefer, in this order, an explicit pattern, an explicit
+    // extention, or a default extension
+    if (this.config.pattern) {
+      this.pattern = this.config.pattern;
+    } else if (this.config.extension) {
+      this.extension = this.config.extension;
+    } else {
+      this.pattern = /\.tag$/;
     }
 
-    compile(file) {
-      var compiled;
-      try {
-        compiled = compile(file.data, this.compiler_options, file.path);
-      } catch (err) {
-        var loc = err.location,
-          error;
-        if (loc) {
-          error = loc.first_line + ":" + loc.first_column + " " + (err.toString());
-        } else {
-          error = err.toString();
-        }
-        return Promise.reject(error);
-      }
-      var result = {
-        data: compiled
+    // Don't try checking for dependencies unless the tag
+    // pre-processor supports it, since progeny may fail
+    // on types it doesn't support.
+    if (this.compiler_options.type == 'jade') {
+      this.getDependencies = function (data, path) {
+        var rootPath = this.rootPath;
+        return new Promise(function (resolve, reject) {
+          progeny({
+            rootPath: rootPath
+          })(path, data, function (e, res) {
+            if (e) {
+              reject(e);
+            } else {
+              resolve(res);
+            }
+          });
+        });
       };
-      return Promise.resolve(result);
     }
+  }
 
-    getDependencies(file) {
-      return new Promise(function (resolve, reject) {
-          progeny({rootPath: this.rootPath})(
-              file.path,
-              file.data,
-              function (err, dependencies) {
-                  if (err) {
-                      reject(err);
-                  } else {
-                      resolve(dependencies);
-                  }
-              });
-      });
+  compile(file) {
+    var compiled;
+    try {
+      compiled = compile(file.data, this.compiler_options, file.path);
+    } catch (err) {
+      var loc = err.location,
+        error;
+      if (loc) {
+        error = loc.first_line + ":" + loc.first_column + " " + (err.toString());
+      } else {
+        error = err.toString();
+      }
+      return Promise.reject(error);
     }
+    var result = {
+      data: compiled
+    };
+    return Promise.resolve(result);
+  }
 }
 
 RiotCompiler.prototype.brunchPlugin = true;

--- a/index.js
+++ b/index.js
@@ -1,53 +1,67 @@
+'use strict';
 var compile = require('riot').compile;
 var progeny = require('progeny');
 
-RiotCompiler = function(config) {
-  this.config = (config && config.plugins && config.plugins.riot) || {};
-  this.rootPath = config.paths.root;
+class RiotCompiler {
+    constructor(config) {
+      this.config = (config && config.plugins && config.plugins.riot) || {};
+      this.rootPath = config.paths.root;
 
-  // grab any compiler options
-  this.compiler_options = {};
-  if (this.config.template) {
-    this.compiler_options.template = this.config.template;
-  }
-  this.compiler_options.type = this.config.type;
+      // grab any compiler options
+      this.compiler_options = {};
+      if (this.config.template) {
+        this.compiler_options.template = this.config.template;
+      }
+      this.compiler_options.type = this.config.type;
 
-  // We prefer, in this order, an explicit pattern, an explicit
-  // extention, or a default extension
-  if (this.config.pattern) {
-    this.pattern = this.config.pattern;
-  } else if (this.config.extension) {
-    this.extension = this.config.extension;
-  } else {
-    this.pattern = /\.tag$/;
-  }
+      // We prefer, in this order, an explicit pattern, an explicit
+      // extention, or a default extension
+      if (this.config.pattern) {
+        this.pattern = this.config.pattern;
+      } else if (this.config.extension) {
+        this.extension = this.config.extension;
+      } else {
+        this.pattern = /\.tag$/;
+      }
+    }
+
+    compile(file) {
+      var compiled;
+      try {
+        compiled = compile(file.data, this.compiler_options, file.path);
+      } catch (err) {
+        var loc = err.location,
+          error;
+        if (loc) {
+          error = loc.first_line + ":" + loc.first_column + " " + (err.toString());
+        } else {
+          error = err.toString();
+        }
+        return Promise.reject(error);
+      }
+      var result = {
+        data: compiled
+      };
+      return Promise.resolve(result);
+    }
+
+    getDependencies(file) {
+      return new Promise(function (resolve, reject) {
+          progeny({rootPath: this.rootPath})(
+              file.path,
+              file.data,
+              function (err, dependencies) {
+                  if (err) {
+                      reject(err);
+                  } else {
+                      resolve(dependencies);
+                  }
+              });
+      });
+    }
 }
 
 RiotCompiler.prototype.brunchPlugin = true;
 RiotCompiler.prototype.type = 'javascript';
-
-RiotCompiler.prototype.compile = function(data, path, callback) {
-  var compiled;
-  try {
-    compiled = compile(data, this.compiler_options, path);
-  } catch (err) {
-    var loc = err.location,
-      error;
-    if (loc) {
-      error = loc.first_line + ":" + loc.first_column + " " + (err.toString());
-    } else {
-      error = err.toString();
-    }
-    return callback(error);
-  }
-  var result = {
-    data: compiled
-  };
-  return callback(null, result);
-};
-
-RiotCompiler.prototype.getDependencies = function(sourceContents, file, callback) {
-  progeny({rootPath: this.rootPath})(file, sourceContents, callback);
-}
 
 module.exports = RiotCompiler;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "riot-brunch",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Adds RiotJS support to brunch.",
   "author": "Artem Yavorsky (http://yavorsky.org)",
   "homepage": "https://github.com/yavorsky/riot-brunch",


### PR DESCRIPTION
The brunch plugin API has changed since this plugin was originally created. (see: https://github.com/brunch/brunch/blob/master/docs/plugins.md)
Prior to this change, the plugin was breaking on the newest release of brunch (2.6.5).

I also updated the code to use the `class` construct - mostly a stylistic choice, but it seems to be the common convention for brunch plugins.
