### PR TITLE
require and export in CommonJS style

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ class RiotCompiler {
   compile(file) {
     var compiled;
     try {
-      compiled = compile(file.data, this.compiler_options, file.path);
+      compiled = "var riot = require('riot');\nmodule.exports = " + compile(file.data, this.compiler_options, file.path);
     } catch (err) {
       var loc = err.location,
         error;


### PR DESCRIPTION
riot-brunch assumes that we have the `riot` global available, meaning I have to add `riot.js` as a vendor script.  This is unnecessary as we're downloading it from the NPM anyway and it can be included with a simple `require`.  This way also means polluting the global scope.

This change does things in what I feel is the "CommonJS way".  The code comes from https://github.com/jhthorsen/riotify/blob/master/index.js#L16 .  We eliminate the vendor script and the global.

Hopefully this helps cut down on configuration clutter for everyone :grinning: .
