### PR TITLE
Update riot version to 3.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "progeny": "^0.5.2",
-    "riot": "^2.3.12"
+    "riot": "^3.3"
   },
   "devDependencies": {
     "babel-core": "^6.4.0",


### PR DESCRIPTION
This patch updates the dependancy to Riot to 3.3 version.

The patch fixes the issue #14 (https://github.com/yavorsky/riot-brunch/issues/14).


We needed it to get a newer riot compiler.