### PR TITLE
Add 'requireRiot' configuration parameter.

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ class RiotCompiler {
   constructor(config) {
     this.config = config.plugins.riot || {};
     this.rootPath = config.paths.root;
+    this.requireRiot = this.config.requireRiot;
 
     // grab any compiler options
     this.compiler_options = {};
@@ -46,7 +47,11 @@ class RiotCompiler {
 
   compile(file) {
     try {
-      return compile(file.data, this.compiler_options, file.path);
+      let result = compile(file.data, this.compiler_options, file.path);
+      if (this.requireRiot) {
+          result = "var riot = require('riot');\n\n" + result;
+      }
+      return result;
     } catch (err) {
       const loc = err.location;
       if (loc) {


### PR DESCRIPTION
I am not sure no one mentioned yet an issue about importing generated tags as modules.
When I simply generate the tags and let brunch bundle them into single js file, the tags cannot be imported. Tag code looks like this:
```
riot.tag2(.......)
```
so a `riot` symbol must be in scope. It is not by default (tag is encapsulated inside of its own module).
The only solution right now is to manually add a globally-scoped `riot` symbol. It is not a nice solution IMO, because it breaks encapsulation.

The solution which is proposed in this PR is to let the `riot-brunch` plugin generate necessary import inside of tag module. This is similar to `-m` flag in `riot-cli`. Unfortunately we cannot reuse this logic because `-m` is handled in the `riot-cli`, not `riot-compiler`.

Commit comment follows:
// ---------------------

Right now when brunch wraps riot-generated code
into module, that module does not have a 'riot' symbol
defined. This causes runtime errors in the browser
when the tag is loaded/imported.

If the 'requireRiot' parameter is set to 'true'
following statement will be prepended to
the compiled template:

  var riot = require('riot');

This way, when the brunch wraps the tag code into
isolated module, 'riot' symbol will be defined
inside of that module.